### PR TITLE
Add routing script for the builtin PHP web server

### DIFF
--- a/builtin.php
+++ b/builtin.php
@@ -1,0 +1,8 @@
+<?php
+// Just serve existing files
+if (is_file(__DIR__ . $_SERVER['REQUEST_URI'])) {
+	return false;
+}
+// Otherwise set URL parameter and start application
+$_GET['url'] = ltrim(preg_replace('/\?.*$/', '', $_SERVER['REQUEST_URI']), '/');
+require "./index.php";


### PR DESCRIPTION
Now the application can be started by using

```
php -S 127.0.0.1:8000 builtin.php
```

from the command line.
