### PR TITLE
Feature: install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ MINI is easy to install, runs nearly everywhere and doesn't make things more com
 ## Installation
 
 1. Edit the database credentials in `application/config/config.php`
-2. Execute the .sql statements in the `_installation/`-folder (with PHPMyAdmin for example).
+2. Execute the .sql statements in the `_installation/`-folder (running `_installation/demo-db.sh <sql username>` or PHPMyAdmin for example).
 3. Make sure you have mod_rewrite activated on your server / in your environment. Some guidelines:
    [Ubuntu 14.04 LTS](http://www.dev-metal.com/enable-mod_rewrite-ubuntu-14-04-lts/),
    [Ubuntu 12.04 LTS](http://www.dev-metal.com/enable-mod_rewrite-ubuntu-12-04-lts/),

--- a/_installation/02-create-table-song.sql
+++ b/_installation/02-create-table-song.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `mini`.`song` (
+CREATE TABLE IF NOT EXISTS `mini`.`song` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `artist` text COLLATE utf8_unicode_ci NOT NULL,
   `track` text COLLATE utf8_unicode_ci NOT NULL,

--- a/_installation/demo-db.sh
+++ b/_installation/demo-db.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+sqlUser=$1
+sqlFiles=(
+  01-create-database.sql
+  02-create-table-song.sql
+  03-insert-demo-data-into-table-song.sql
+)
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+directory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+for file in ${sqlFiles[@]}
+do
+  mysql --user="${sqlUser}" < ${directory}/${file}
+done


### PR DESCRIPTION
Providing a Bash install script to make the install process easier. May not be a big thing but IMHO definitely a step in the right direction.

The script is located in the `_installation/` directory and can be run like `demo-db.sh <sql username>`.
